### PR TITLE
Fix event propagation at button

### DIFF
--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -57,7 +57,7 @@ class Button extends PureComponent {
     })
 
     if (this.props.onClick) {
-      this.props.onClick()
+      this.props.onClick(e)
     }
   }
 


### PR DESCRIPTION
# Description

If you propagate the event from the onClick event we can forward this to the props.onClick provided handler